### PR TITLE
Add certificate tech contact fields

### DIFF
--- a/pkg/domain/certificates/certificate.go
+++ b/pkg/domain/certificates/certificate.go
@@ -29,6 +29,8 @@ type Certificate struct {
 	ApiKey                      string
 	ApiKeyNew                   string
 	ApiKeyViaUrl                bool
+	TechPhone                   string
+	TechEmail                   string
 	PostProcessingCommand       string
 	PostProcessingEnvironment   []string
 	PostProcessingClientAddress string
@@ -110,6 +112,8 @@ type certificateDetailedResponse struct {
 	UpdatedAt                   int64               `json:"updated_at"`
 	ApiKey                      string              `json:"api_key"`
 	ApiKeyNew                   string              `json:"api_key_new,omitempty"`
+	TechPhone                   string              `json:"tech_phone"`
+	TechEmail                   string              `json:"tech_email"`
 	PostProcessingCommand       string              `json:"post_processing_command"`
 	PostProcessingEnvironment   []string            `json:"post_processing_environment"`
 	PostProcessingClientAddress string              `json:"post_processing_client_address"`
@@ -138,6 +142,8 @@ func (cert Certificate) detailedResponse() certificateDetailedResponse {
 		UpdatedAt:                   cert.UpdatedAt.Unix(),
 		ApiKey:                      cert.ApiKey,
 		ApiKeyNew:                   cert.ApiKeyNew,
+		TechPhone:                   cert.TechPhone,
+		TechEmail:                   cert.TechEmail,
 		PostProcessingCommand:       cert.PostProcessingCommand,
 		PostProcessingEnvironment:   cert.PostProcessingEnvironment,
 		PostProcessingClientAddress: cert.PostProcessingClientAddress,

--- a/pkg/domain/certificates/handlers_post.go
+++ b/pkg/domain/certificates/handlers_post.go
@@ -37,6 +37,8 @@ type NewPayload struct {
 	PostProcessingClientAddress *string             `json:"post_processing_client_address"`
 	PostProcessingClientKeyB64  string              `json:"-"`
 	Profile                     *string             `json:"profile"`
+	TechPhone                   *string             `json:"tech_phone"`
+	TechEmail                   *string             `json:"tech_email"`
 	ApiKey                      string              `json:"-"`
 	ApiKeyViaUrl                bool                `json:"-"`
 	CreatedAt                   int                 `json:"-"`
@@ -193,6 +195,30 @@ func (service *Service) PostNewCert(w http.ResponseWriter, r *http.Request) *out
 		if !valid {
 			service.logger.Debug(ErrClientAddressBad)
 			return output.JsonErrValidationFailed(ErrClientAddressBad)
+		}
+	}
+	// end validation
+
+	// tech phone number
+	if payload.TechPhone == nil {
+		payload.TechPhone = new(string)
+	} else if *payload.TechPhone != "" {
+		valid := validation.PhoneValid(*payload.TechPhone)
+		if !valid {
+			service.logger.Debug(ErrPhoneBad)
+			return output.JsonErrValidationFailed(ErrPhoneBad)
+		}
+	}
+	// end validation
+
+	// tech email address
+	if payload.TechEmail == nil {
+		payload.TechEmail = new(string)
+	} else if *payload.TechEmail != "" {
+		valid := validation.EmailValid(*payload.TechEmail)
+		if !valid {
+			service.logger.Debug(ErrEmailBad)
+			return output.JsonErrValidationFailed(ErrEmailBad)
 		}
 	}
 	// end validation

--- a/pkg/domain/certificates/handlers_put.go
+++ b/pkg/domain/certificates/handlers_put.go
@@ -34,6 +34,8 @@ type DetailsUpdatePayload struct {
 	ApiKey                      *string             `json:"api_key"`
 	ApiKeyNew                   *string             `json:"api_key_new"`
 	ApiKeyViaUrl                *bool               `json:"api_key_via_url"`
+	TechPhone                   *string             `json:"tech_phone"`
+	TechEmail                   *string             `json:"tech_email"`
 	UpdatedAt                   int                 `json:"-"`
 }
 
@@ -135,6 +137,32 @@ func (service *Service) PutDetailsCert(w http.ResponseWriter, r *http.Request) *
 		if !valid {
 			service.logger.Debug(ErrClientAddressBad)
 			return output.JsonErrValidationFailed(ErrClientAddressBad)
+		}
+	}
+
+	// end validation
+
+	// tech phone number
+	if payload.TechPhone == nil {
+		payload.TechPhone = new(string)
+	} else if *payload.TechPhone != "" {
+		valid := validation.PhoneValid(*payload.TechPhone)
+		if !valid {
+			service.logger.Debug(ErrPhoneBad)
+			return output.JsonErrValidationFailed(ErrPhoneBad)
+		}
+	}
+
+	// end validation
+
+	// tech email address
+	if payload.TechEmail == nil {
+		payload.TechEmail = new(string)
+	} else if *payload.TechEmail != "" {
+		valid := validation.EmailValid(*payload.TechEmail)
+		if !valid {
+			service.logger.Debug(ErrEmailBad)
+			return output.JsonErrValidationFailed(ErrEmailBad)
 		}
 	}
 

--- a/pkg/domain/certificates/validation.go
+++ b/pkg/domain/certificates/validation.go
@@ -28,6 +28,10 @@ var (
 	// domain
 	ErrDomainBad        = errors.New("domain or subject name not valid")
 	ErrClientAddressBad = errors.New("client address is not valid")
+
+	// tech contacts
+	ErrPhoneBad        = errors.New("contact phone is not valid")
+	ErrEmailBad        = errors.New("contact email is not valid")
 )
 
 // GetCertificate returns the Certificate for the specified id.

--- a/pkg/domain/orders/post_process_do_script.go
+++ b/pkg/domain/orders/post_process_do_script.go
@@ -41,6 +41,8 @@ func (j *postProcessJob) doScriptOrBinaryPostProcess(order Order, workerID int) 
 	// {{CERTIFICATE_NAME}}					= the `Name` of the certificate
 	// {{CERTIFICATE_PEM}}					= the pem of the complete certificate chain for the order
 	// {{CERTIFICATE_COMMON_NAME}}	= the common name of the certificate
+	// {{TECH_PHONE}}					= the tech contact phone number
+	// {{TECH_EMAIL}}					= the tech contact email address
 
 	// make Params (which sanitizes the env params and handles things like removing quotes)
 	envParams, invalidParams := environment.NewParams(order.Certificate.PostProcessingEnvironment)
@@ -66,6 +68,12 @@ func (j *postProcessJob) doScriptOrBinaryPostProcess(order Order, workerID int) 
 
 		case "{{CERTIFICATE_COMMON_NAME}}":
 			val = order.Certificate.Subject
+
+		case "{{TECH_PHONE}}":
+			val = order.Certificate.TechPhone
+
+		case "{{TECH_EMAIL}}":
+			val = order.Certificate.TechEmail
 
 		default:
 			// no-op - user specified some other value

--- a/pkg/storage/sqlite/certificates.go
+++ b/pkg/storage/sqlite/certificates.go
@@ -33,6 +33,8 @@ type certificateDb struct {
 	postProcessingClientAddress string
 	postProcessingClientKeyB64  string // base64 raw url encoded AES 256 key
 	profile                     string
+	techPhone                   string
+	techEmail                   string
 }
 
 func (cert certificateDb) toCertificate() (certificates.Certificate, error) {
@@ -67,5 +69,7 @@ func (cert certificateDb) toCertificate() (certificates.Certificate, error) {
 		PostProcessingClientAddress: cert.postProcessingClientAddress,
 		PostProcessingClientKeyB64:  cert.postProcessingClientKeyB64,
 		Profile:                     cert.profile,
+		TechPhone:                   cert.techPhone,
+		TechEmail:                   cert.techEmail,
 	}, nil
 }

--- a/pkg/storage/sqlite/certificates_get.go
+++ b/pkg/storage/sqlite/certificates_get.go
@@ -50,7 +50,7 @@ func (store *Storage) GetAllCerts(q pagination_sort.Query) (certs []certificates
 		c.csr_org, c.csr_ou, c.csr_country, c.csr_state, c.csr_city, c.csr_extra_extensions, c.preferred_root_cn,
 		c.last_access, c.created_at, c.updated_at,
 		c.api_key, c.api_key_new, c.api_key_via_url, c.post_processing_command, c.post_processing_environment,
-		c.post_processing_client_address, c.post_processing_client_key, c.profile,
+		c.post_processing_client_address, c.post_processing_client_key, c.profile, c.tech_phone, c.tech_email,
 		
 		pk.id, pk.name, pk.description, pk.algorithm, pk.pem, pk.api_key, pk.api_key_new,
 		pk.api_key_disabled, pk.api_key_via_url, pk.last_access, pk.created_at, pk.updated_at,
@@ -118,6 +118,8 @@ func (store *Storage) GetAllCerts(q pagination_sort.Query) (certs []certificates
 			&oneCert.postProcessingClientAddress,
 			&oneCert.postProcessingClientKeyB64,
 			&oneCert.profile,
+			&oneCert.techPhone,
+			&oneCert.techEmail,
 
 			&oneCert.certificateKeyDb.id,
 			&oneCert.certificateKeyDb.name,
@@ -202,7 +204,7 @@ func (store *Storage) getOneCert(id int, name string) (cert certificates.Certifi
 		c.csr_org, c.csr_ou, c.csr_country, c.csr_state, c.csr_city, c.csr_extra_extensions, c.preferred_root_cn,
 		c.last_access, c.created_at, c.updated_at,
 		c.api_key, c.api_key_new, c.api_key_via_url, c.post_processing_command, c.post_processing_environment,
-		c.post_processing_client_address, c.post_processing_client_key, c.profile,
+		c.post_processing_client_address, c.post_processing_client_key, c.profile, c.tech_phone, c.tech_email,
 		
 		pk.id, pk.name, pk.description, pk.algorithm, pk.pem, pk.api_key, pk.api_key_new,
 		pk.api_key_disabled, pk.api_key_via_url, pk.last_access, pk.created_at, pk.updated_at,
@@ -254,6 +256,8 @@ func (store *Storage) getOneCert(id int, name string) (cert certificates.Certifi
 		&oneCert.postProcessingClientAddress,
 		&oneCert.postProcessingClientKeyB64,
 		&oneCert.profile,
+		&oneCert.techPhone,
+		&oneCert.techEmail,
 
 		&oneCert.certificateKeyDb.id,
 		&oneCert.certificateKeyDb.name,

--- a/pkg/storage/sqlite/certificates_post.go
+++ b/pkg/storage/sqlite/certificates_post.go
@@ -20,8 +20,8 @@ func (store *Storage) PostNewCert(payload certificates.NewPayload) (certificates
 		csr_org, csr_ou, csr_country, csr_state, csr_city, csr_extra_extensions, preferred_root_cn, 
 		created_at, updated_at, api_key, api_key_via_url,
 		post_processing_command, post_processing_environment, post_processing_client_address, 
-		post_processing_client_key, profile)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+		post_processing_client_key, profile, tech_phone, tech_email)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
 	RETURNING id
 	`
 
@@ -49,6 +49,8 @@ func (store *Storage) PostNewCert(payload certificates.NewPayload) (certificates
 		payload.PostProcessingClientKeyB64,
 		payload.PostProcessingClientAddress,
 		payload.Profile,
+		payload.TechPhone,
+		payload.TechEmail,
 	).Scan(&id)
 
 	if err != nil {

--- a/pkg/storage/sqlite/certificates_put.go
+++ b/pkg/storage/sqlite/certificates_put.go
@@ -35,9 +35,11 @@ func (store *Storage) PutDetailsCert(payload certificates.DetailsUpdatePayload) 
 			post_processing_environment = case when $16 is null then post_processing_environment else $16 end,
 			post_processing_client_address = case when $17 is null then post_processing_client_address else $17 end,
 			profile = case when $18 is null then profile else $18 end,
-			updated_at = $19
+			tech_phone = case when $19 is null then profile else $19 end,
+			tech_email = case when $20 is null then profile else $20 end,
+			updated_at = $21
 		WHERE
-			id = $20
+			id = $22
 		`
 
 	_, err := store.db.ExecContext(ctx, query,
@@ -59,6 +61,8 @@ func (store *Storage) PutDetailsCert(payload certificates.DetailsUpdatePayload) 
 		makeJsonStringSlice(payload.PostProcessingEnvironment),
 		payload.PostProcessingClientAddress,
 		payload.Profile,
+		payload.TechPhone,
+		payload.TechEmail,
 		payload.UpdatedAt,
 		payload.ID,
 	)

--- a/pkg/storage/sqlite/orders_get.go
+++ b/pkg/storage/sqlite/orders_get.go
@@ -53,6 +53,7 @@ func (store *Storage) GetAllValidCurrentOrders(q pagination_sort.Query) (orders 
 		c.csr_org, c.csr_ou, c.csr_country, c.csr_state, c.csr_city, c.csr_extra_extensions, c.preferred_root_cn,
 		c.last_access, c.created_at, c.updated_at, c.api_key, c.api_key_new, c.api_key_via_url, c.post_processing_command, 
 		c.post_processing_environment, c.post_processing_client_address, c.post_processing_client_key, c.profile,
+		c.tech_phone, c.tech_email,
 		
 		/* cert's key */
 		ck.id, ck.name, ck.description, ck.algorithm, ck.pem, ck.api_key, ck.api_key_new,
@@ -168,6 +169,8 @@ func (store *Storage) GetAllValidCurrentOrders(q pagination_sort.Query) (orders 
 			&oneOrder.certificate.postProcessingClientAddress,
 			&oneOrder.certificate.postProcessingClientKeyB64,
 			&oneOrder.certificate.profile,
+			&oneOrder.certificate.techPhone,
+			&oneOrder.certificate.techEmail,
 
 			&oneOrder.certificate.certificateKeyDb.id,
 			&oneOrder.certificate.certificateKeyDb.name,
@@ -287,6 +290,7 @@ func (store *Storage) GetOrdersByCert(certId int, q pagination_sort.Query) (orde
 		c.last_access, c.created_at, c.updated_at,
 		c.api_key, c.api_key_new, c.api_key_via_url, c.post_processing_command, c.post_processing_environment,
 		c.post_processing_client_address, c.post_processing_client_key, c.profile,
+		c.tech_phone, c.tech_email,
 		
 		/* cert's key */
 		ck.id, ck.name, ck.description, ck.algorithm, ck.pem, ck.api_key, ck.api_key_new, ck.api_key_disabled,
@@ -388,6 +392,8 @@ func (store *Storage) GetOrdersByCert(certId int, q pagination_sort.Query) (orde
 			&oneOrder.certificate.postProcessingClientAddress,
 			&oneOrder.certificate.postProcessingClientKeyB64,
 			&oneOrder.certificate.profile,
+			&oneOrder.certificate.techPhone,
+			&oneOrder.certificate.techEmail,
 
 			&oneOrder.certificate.certificateKeyDb.id,
 			&oneOrder.certificate.certificateKeyDb.name,
@@ -575,7 +581,7 @@ func (store *Storage) GetOrders(orderIDs []int) (orders []orders.Order, err erro
 		c.csr_org, c.csr_ou, c.csr_country, c.csr_state, c.csr_city, c.csr_extra_extensions, c.preferred_root_cn,
 		c.last_access, c.created_at, c.updated_at,
 		c.api_key, c.api_key_new, c.api_key_via_url, c.post_processing_command, c.post_processing_environment,
-		c.post_processing_client_address, c.post_processing_client_key, c.profile, 
+		c.post_processing_client_address, c.post_processing_client_key, c.profile, c.tech_phone, c.tech_email,
 		
 		/* cert's key */
 		ck.id, ck.name, ck.description, ck.algorithm, ck.pem, ck.api_key, ak.api_key_new, ck.api_key_disabled,
@@ -663,6 +669,8 @@ func (store *Storage) GetOrders(orderIDs []int) (orders []orders.Order, err erro
 			&oneOrder.certificate.postProcessingClientAddress,
 			&oneOrder.certificate.postProcessingClientKeyB64,
 			&oneOrder.certificate.profile,
+			&oneOrder.certificate.techPhone,
+			&oneOrder.certificate.techEmail,
 
 			&oneOrder.certificate.certificateKeyDb.id,
 			&oneOrder.certificate.certificateKeyDb.name,
@@ -783,7 +791,7 @@ func (store *Storage) getCertNewestValidOrder(certId int, certName string) (orde
 		c.csr_org, c.csr_ou, c.csr_country, c.csr_state, c.csr_city, c.csr_extra_extensions, c.preferred_root_cn,
 		c.last_access, c.created_at, c.updated_at,
 		c.api_key, c.api_key_new, c.api_key_via_url, c.post_processing_command, c.post_processing_environment,
-		c.post_processing_client_address, c.post_processing_client_key, c.profile,
+		c.post_processing_client_address, c.post_processing_client_key, c.profile, c.tech_phone, c.tech_email,
 		
 		/* cert's key */
 		ck.id, ck.name, ck.description, ck.algorithm, ck.pem, ck.api_key, ak.api_key_new, ck.api_key_disabled,
@@ -886,6 +894,8 @@ func (store *Storage) getCertNewestValidOrder(certId int, certName string) (orde
 		&oneOrder.certificate.postProcessingClientAddress,
 		&oneOrder.certificate.postProcessingClientKeyB64,
 		&oneOrder.certificate.profile,
+		&oneOrder.certificate.techPhone,
+		&oneOrder.certificate.techEmail,
 
 		&oneOrder.certificate.certificateKeyDb.id,
 		&oneOrder.certificate.certificateKeyDb.name,

--- a/pkg/storage/sqlite/setup_migrate_v12.go
+++ b/pkg/storage/sqlite/setup_migrate_v12.go
@@ -1,0 +1,244 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// CHANGES v11 to v12:
+// - certificates:
+//		 - Add 'tech_phone' and 'tech_email' fields/columns
+
+// createDBTablesV12 creates a fresh set of tables in the db using schema version specified
+func createDBTablesV12(tx *sql.Tx) error {
+	// acme_servers
+	query := `CREATE TABLE IF NOT EXISTS acme_servers (
+		id integer PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+		name text NOT NULL UNIQUE COLLATE NOCASE,
+		description text NOT NULL,
+		directory_url text NOT NULL UNIQUE,
+		is_staging integer NOT NULL DEFAULT 0 CHECK(is_staging IN (0,1)),
+		created_at integer NOT NULL,
+		updated_at integer NOT NULL
+	)`
+
+	_, err := tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	// private_keys
+	query = `CREATE TABLE IF NOT EXISTS private_keys (
+		id integer PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+		name text NOT NULL UNIQUE COLLATE NOCASE,
+		description text NOT NULL,
+		algorithm text NOT NULL,
+		pem text NOT NULL UNIQUE,
+		api_key text NOT NULL,
+		api_key_new text NOT NULL DEFAULT '',
+		api_key_disabled integer NOT NULL DEFAULT 0 CHECK(api_key_disabled IN (0,1)),
+		api_key_via_url integer NOT NULL DEFAULT 0 CHECK(api_key_via_url IN (0,1)),
+		last_access integer NOT NULL DEFAULT 0,
+		created_at integer NOT NULL,
+		updated_at integer NOT NULL
+	)`
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	// acme_accounts
+	query = `CREATE TABLE IF NOT EXISTS acme_accounts (
+		id integer PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+		name text NOT NULL UNIQUE COLLATE NOCASE,
+		private_key_id integer NOT NULL UNIQUE,
+		description text NOT NULL,
+		status text NOT NULL DEFAULT 'unknown',
+		email text NOT NULL,
+		accepted_tos integer NOT NULL DEFAULT 0 CHECK(accepted_tos IN (0,1)),
+		created_at integer NOT NULL,
+		updated_at integer NOT NULL,
+		kid text NOT NULL,
+		acme_server_id integer NOT NULL,
+		FOREIGN KEY (private_key_id)
+			REFERENCES private_keys (id)
+				ON DELETE RESTRICT
+				ON UPDATE NO ACTION,
+		FOREIGN KEY (acme_server_id)
+			REFERENCES acme_servers (id)
+				ON DELETE RESTRICT
+				ON UPDATE NO ACTION
+	)`
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	// certificates
+	query = `CREATE TABLE IF NOT EXISTS certificates (
+		id integer PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+		private_key_id integer NOT NULL UNIQUE,
+		acme_account_id integer NOT NULL,
+		name text NOT NULL UNIQUE COLLATE NOCASE,
+		description text NOT NULL,
+		subject text NOT NULL,
+		subject_alts text NOT NULL,
+		csr_org text NOT NULL,
+		csr_ou text NOT NULL,
+		csr_country text NOT NULL,
+		csr_state text NOT NULL,
+		csr_city text NOT NULL,
+		csr_extra_extensions text NOT NULL DEFAULT "[]",
+		preferred_root_cn text NOT NULL DEFAULT "",
+		api_key text NOT NULL,
+		api_key_new text NOT NULL DEFAULT '',
+		api_key_via_url integer NOT NULL DEFAULT 0 CHECK(api_key_via_url IN (0,1)),
+		last_access integer NOT NULL DEFAULT 0,
+		created_at integer NOT NULL,
+		updated_at integer NOT NULL,
+		post_processing_command text NOT NULL DEFAULT "",
+		post_processing_environment text NOT NULL DEFAULT "[]",
+		post_processing_client_address text NOT NULL DEFAULT "",
+		post_processing_client_key text NOT NULL DEFAULT "",
+		profile text NOT NULL DEFAULT "",
+		tech_phone text NOT NULL DEFAULT "",
+		tech_email text NOT NULL DEFAULT "",
+		FOREIGN KEY (private_key_id)
+			REFERENCES private_keys (id)
+				ON DELETE RESTRICT
+				ON UPDATE NO ACTION,
+		FOREIGN KEY (acme_account_id)
+			REFERENCES acme_accounts (id)
+				ON DELETE RESTRICT
+				ON UPDATE NO ACTION
+	)`
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	// ACME orders
+	query = `CREATE TABLE IF NOT EXISTS acme_orders (
+			id integer PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+			acme_account_id integer NOT NULL,
+			certificate_id integer NOT NULL,
+			acme_location text NOT NULL UNIQUE,
+			status text NOT NULL,
+			known_revoked integer NOT NULL DEFAULT 0 CHECK(known_revoked IN (0,1)),
+			error text,
+			expires integer,
+			dns_identifiers text NOT NULL,
+			authorizations text NOT NULL,
+			finalize text NOT NULL,
+			finalized_key_id integer,
+			certificate_url text,
+			pem text,
+			valid_from integer,
+			valid_to integer,
+			chain_root_cn text,
+			created_at integer NOT NULL,
+			updated_at integer NOT NULL,
+			profile text DEFAULT NULL,
+			renewal_info text DEFAULT NULL,
+			FOREIGN KEY (acme_account_id)
+				REFERENCES acme_accounts (id)
+					ON DELETE CASCADE
+					ON UPDATE NO ACTION,
+			FOREIGN KEY (finalized_key_id)
+				REFERENCES private_keys (id)
+					ON DELETE SET NULL
+					ON UPDATE NO ACTION,
+			FOREIGN KEY (certificate_id)
+				REFERENCES certificates (id)
+					ON DELETE CASCADE
+					ON UPDATE NO ACTION
+		)`
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	// users (for login to app)
+	query = `CREATE TABLE IF NOT EXISTS users (
+		id integer PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+		username text NOT NULL UNIQUE,
+		password_hash NOT NULL,
+		created_at integer NOT NULL,
+		updated_at integer NOT NULL
+	)`
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// migrateV11toV12 modifies the db to the specified schema, if it cannot
+// do so, an error is returned and modification is aborted
+func (store *Storage) migrateV11toV12() (int, error) {
+	oldSchemaVer := 11
+	newSchemaVer := 12
+
+	store.logger.Infof("updating database user_version from %d to %d", oldSchemaVer, newSchemaVer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), store.timeout)
+	defer cancel()
+
+	// create sql transaction to roll back in the event an error occurs
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return -1, err
+	}
+	defer tx.Rollback()
+
+	// verify correct current ver
+	query := `PRAGMA user_version`
+	row := tx.QueryRowContext(ctx, query)
+	fileUserVersion := -1
+	err = row.Scan(
+		&fileUserVersion,
+	)
+	if err != nil {
+		return -1, err
+	}
+	if fileUserVersion != oldSchemaVer {
+		return -1, fmt.Errorf("cannot update db schema, current version %d (expected %d)", fileUserVersion, oldSchemaVer)
+	}
+
+	// add tech_phone and tech_email columns to certificates
+	query = `
+		ALTER TABLE certificates ADD tech_phone text NOT NULL DEFAULT "";
+		ALTER TABLE certificates ADD tech_email text NOT NULL DEFAULT "";
+	`
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return -1, err
+	}
+
+	// update user_version
+	query = fmt.Sprintf(`
+		PRAGMA user_version = %d
+	`, newSchemaVer)
+
+	_, err = tx.Exec(query)
+	if err != nil {
+		return -1, err
+	}
+
+	// no errors, commit transaction
+	err = tx.Commit()
+	if err != nil {
+		return -1, err
+	}
+
+	store.logger.Infof("database user_version successfully upgraded from %d to %d", oldSchemaVer, newSchemaVer)
+	return newSchemaVer, nil
+}

--- a/pkg/validation/phone.go
+++ b/pkg/validation/phone.go
@@ -1,0 +1,29 @@
+package validation
+
+import "regexp"
+
+// Phone number format:
+// +<countrycode><subscriber number>
+// Example: +351123456789
+//
+// Country code: 1–3 digits
+// Subscriber number: 4–14 digits
+//
+// Example full lengths: +1XXXXXXXXXX, +351XXXXXXXXX
+//
+// Regex explanation:
+// ^\+		 literal +
+// [1-9]\d{0,2}	 country code, 1–3 digits, not starting with 0
+// \d{4,14}$	 subscriber number: 4–14 digits
+//
+var phoneRegex = regexp.MustCompile(`^\+[1-9]\d{0,2}\d{4,14}$`)
+
+// PhoneValid returns true if the phone number is valid.
+func PhoneValid(phone string) bool {
+    return phoneRegex.MatchString(phone)
+}
+
+// PhoneValidOrBlank returns true if the phone number is empty or valid.
+func PhoneValidOrBlank(phone string) bool {
+    return phone == "" || PhoneValid(phone)
+}

--- a/pkg/validation/phone_test.go
+++ b/pkg/validation/phone_test.go
@@ -1,0 +1,85 @@
+package validation
+
+import "testing"
+
+// validPhones is a list of valid phone numbers in the format:
+// +<countrycode><number>
+var validPhones = []string{
+	"+14155552671",	   // US
+	"+351123456789",   // Portugal
+	"+447911123456",   // UK
+	"+4930123456",	   // Germany
+	"+818012345678",   // Japan
+	"+61234567890",	   // Australia (example)
+	"+972501234567",   // Israel
+}
+
+// invalidPhones is a list of phone numbers that must fail validation.
+var invalidPhones = []string{
+	"14155552671",	    // missing +
+	"+014155552671",    // country code starting with 0
+	"+1",		    // too short
+	"+123",		    // too short for subscriber number
+	"+351-123456789",   // invalid character
+	"+351 123456789",   // space not allowed
+	"+351123456789abcdef", // letters not allowed
+	"+---123456",	    // nonsense
+	"+999999999999999999", // too long
+	"+",		    // just plus
+	"",		    // empty is handled separately
+}
+
+// makeValidPhones returns valid test cases
+func makeValidPhones() []string {
+	valid := []string{}
+	for _, phone := range validPhones {
+		valid = append(valid, phone)
+	}
+	return valid
+}
+
+// makeInvalidPhones returns invalid test cases
+func makeInvalidPhones() []string {
+	invalid := []string{}
+	for _, phone := range invalidPhones {
+		invalid = append(invalid, phone)
+	}
+	return invalid
+}
+
+func TestValidation_PhoneValid(t *testing.T) {
+	// test valid phones
+	for _, phone := range makeValidPhones() {
+		if !PhoneValid(phone) {
+			t.Errorf("valid phone test case '%s' returned invalid", phone)
+		}
+	}
+
+	// test invalid phones
+	for _, phone := range makeInvalidPhones() {
+		if PhoneValid(phone) {
+			t.Errorf("invalid phone test case '%s' returned valid", phone)
+		}
+	}
+}
+
+func TestValidation_PhoneValidOrBlank(t *testing.T) {
+	// test blank input
+	if !PhoneValidOrBlank("") {
+		t.Error("valid phone or blank test case '' (i.e., blank) returned invalid")
+	}
+
+	// test valid phones
+	for _, phone := range makeValidPhones() {
+		if !PhoneValidOrBlank(phone) {
+			t.Errorf("valid phone or blank test case '%s' returned invalid", phone)
+		}
+	}
+
+	// test invalid phones
+	for _, phone := range makeInvalidPhones() {
+		if PhoneValidOrBlank(phone) {
+			t.Errorf("invalid phone or blank test case '%s' returned valid", phone)
+		}
+	}
+}


### PR DESCRIPTION
This PR aims at adding two new fields to certificate entries, Technical Contact Telephone number and Technical Contact Email address.
Besides the informational character, these new fields are made available to the Post Script processing facility through the dynamic variables {{TECH_PHONE}} and {{TECH_EMAIL}}, making it easier to automate certificate distribution and notification to clients that don't have access to Certwarden's Web interface.

Note: to be addressed in conjunction with [certwarden-frontend PR#8](https://github.com/gregtwallace/certwarden-frontend/pull/8)